### PR TITLE
Add 'computer-science'

### DIFF
--- a/computer-science/index.js
+++ b/computer-science/index.js
@@ -1,0 +1,809 @@
+/** A LinkedList implementation using nodes liked by reference */
+class LinkedList {
+  /**
+   * The head node in the list
+   * @private
+   * @type {Object}
+   */
+  head = null;
+
+  /**
+   * The tail node in the list
+   * @private
+   * @type {Object}
+   */
+  tail = null;
+
+  /**
+   * The number of items in the list
+   * @type {number}
+   */
+  size = 0;
+
+  /**
+   * @param {array} [items] an array of items to add to the list
+   */
+  constructor (items) {
+    if (items) {
+      this.addAll(items);
+    }
+  }
+
+  /**
+   * Add an item to the list
+   *
+   * @param {*} item an item to add to the list
+   */
+  add (item = null) {
+    if (item === null) { throw Error('\'item\' parameter not defined'); }
+    if (this.size === 0) {
+      this.tail = new ListNode(item, null);
+      this.head = this.tail;
+    } else {
+      const prev = this.tail;
+      this.tail = new ListNode(item, null);
+      prev.next = this.tail;
+    }
+    this.size++;
+  }
+
+  /**
+   * Add multiple items to the list
+   *
+   * @param {*[]} items an array of items to be added to the list
+   */
+  addAll (items = null) {
+    if (items === null) { throw Error('\'items\' parameter not defined'); }
+
+    items.forEach(item => this.add(item));
+  }
+
+  /**
+   * Remove an item from the list
+   *
+   * @param {*} item the item to remove from the list
+   * @returns {boolean} true if the item was successfully removed, false if not
+   */
+  remove (item = null) {
+    if (item === null) { throw Error('\'item\' parameter not defined'); }
+    if (this.size === 0) { throw Error('can\'t remove an item from an empty list'); }
+
+    let prev = this.head;
+    let curr = this.head;
+    while (curr != null) {
+      if (curr.data === item) {
+        if (this.size === 1) { // remove the last remaining element
+          this.head = null;
+          this.tail = null;
+        } else if (curr === this.head) { // remove first element
+          this.head = this.head.next;
+        } else if (curr === this.tail) { // remove last element
+          this.tail = prev;
+          this.tail.next = null;
+        } else { // remove element
+          prev.next = curr.next;
+        }
+        this.size--;
+
+        return true;
+      }
+      prev = curr;
+      curr = prev.next;
+    }
+
+    return false;
+  }
+
+  /**
+   * Remove all items from the list
+   * @method
+   */
+  clear () {
+    this.head = null;
+    this.tail = null;
+    this.size = 0;
+  }
+
+  /**
+   * Iterate all items (in-order) in the list
+   *
+   * @private
+   * @returns {Iterator<*>} an iterator for the data
+   */
+  [Symbol.iterator] () {
+    let item = this.head;
+    return {
+      next: () => {
+        if (item) {
+          const value = item.data;
+          item = item.next;
+          return { value, done: false };
+        }
+
+        return { value: null, done: true };
+      }
+    };
+  }
+}
+
+/**
+ * @private
+ */
+class ListNode {
+  data;
+  next;
+
+  constructor (data, next = null) {
+    this.data = data;
+    this.next = next;
+  }
+}
+
+/** A Queue implementation using nodes liked by reference */
+class Queue {
+  /**
+   * The first item in the queue
+   * @private
+   * @type {Object}
+   */
+  first = null;
+
+  /**
+   * The last item in the queue
+   * @private
+   * @type {Object}
+   */
+  last = null;
+
+  /**
+   * The number of items in the queue
+   * @type {number}
+   */
+  size = 0;
+
+  /**
+   * @param {array} [items] an array of items to add to the queue
+   */
+  constructor (items) {
+    if (items) {
+      this.enqueueAll(items);
+    }
+  }
+
+  /**
+   * Add an item to the end of the queue
+   *
+   * @param {*} item an item to add to the queue
+   */
+  enqueue (item = null) {
+    if (item === null) { throw Error('\'item\' parameter not defined'); }
+    if (this.size !== 0) {
+      const prevLast = this.last;
+      this.last = new QueueNode(item, null);
+      prevLast.link = this.last;
+    } else {
+      this.first = new QueueNode(item, null);
+      this.last = this.first;
+    }
+    this.size++;
+  }
+
+  /**
+   * Add multiple items to the end of the queue
+   *
+   * @param {*[]} items an array of items to be added to the queue
+   */
+  enqueueAll (items = null) {
+    if (items === null) { throw Error('\'items\' parameter not defined'); }
+
+    items.forEach(item => this.enqueue(item));
+  }
+
+  /**
+   * Remove and return the first item in the queue
+   *
+   * @returns {*} removes and returns the last item in the queue
+   */
+  dequeue () {
+    if (this.size === 0) { throw Error('can\'t dequeue an item from an empty queue'); }
+    const dequeued = this.first;
+    if (this.size === 1) {
+      this.first = null;
+      this.last = null;
+    } else {
+      this.first = dequeued.link;
+    }
+    this.size--;
+
+    return dequeued.data;
+  }
+
+  /**
+   * Return the first item in the queue
+   *
+   * @returns {*} the last item in the queue
+   */
+  peek () {
+    if (this.size === 0) { throw Error('can\'t peek an item from an empty stack'); }
+
+    return this.first.data;
+  }
+
+  /**
+   * Remove all items from the queue
+   * @method
+   */
+  clear () {
+    this.first = null;
+    this.last = null;
+    this.size = 0;
+  }
+
+  /**
+   * Iterate all items (first-to-last) in the queue
+   *
+   * @private
+   * @returns {Iterator<*>}
+   */
+  [Symbol.iterator] () {
+    let item = this.first;
+    return {
+      next: () => {
+        if (item) {
+          const value = item.data;
+          item = item.link;
+          return { value, done: false };
+        }
+
+        return { value: null, done: true };
+      }
+    };
+  }
+}
+
+/**
+ * @private
+ */
+class QueueNode {
+  data;
+  link;
+
+  constructor (data, link = null) {
+    this.data = data;
+    this.link = link;
+  }
+}
+
+/** A Set implementation using an array */
+class Set {
+  /**
+   * The set's values
+   * @private
+   * @type {array}
+   */
+  values = [];
+
+  /**
+   * The number of items in the set
+   * @type {number}
+   */
+  size = 0;
+
+  /**
+   * @param {array} [items] an array of items to add to the set
+   */
+  constructor (items) {
+    if (items) {
+      this.addAll(items);
+    }
+  }
+
+  /**
+   * Add an item to the set
+   *
+   * @param {*} item an item to add to the set
+   */
+  add (item = null) {
+    if (item === null) { throw Error('\'item\' parameter not defined'); }
+    if (!this.values.includes(item)) {
+      this.values.push(item);
+      this.size++;
+    }
+  }
+
+  /**
+   * Add multiple items to the set
+   *
+   * @param {*[]} items an array of items to be added to the set
+   */
+  addAll (items = null) {
+    if (items === null) { throw Error('\'items\' parameter not defined'); }
+
+    items.forEach(item => this.add(item));
+  }
+
+  /**
+   * Remove an item from the set
+   *
+   * @param {*} item the item to remove from the set
+   * @returns {boolean} true if the item was successfully removed, false if not
+   */
+  remove (item = null) {
+    if (item === null) { throw Error('\'item\' parameter not defined'); }
+    const index = this.values.indexOf(item);
+    if (index !== -1) {
+      this.values = [...this.values.slice(0, index), ...this.values.slice(index + 1)];
+      this.size--;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Remove all items from the set
+   * @method
+   */
+  clear () {
+    this.values = [];
+    this.size = 0;
+  }
+
+  /**
+   * Iterate all items in the set
+   *
+   * @private
+   * @returns {Iterator<*>} an iterator for the data
+   */
+  [Symbol.iterator] () {
+    return this.values[Symbol.iterator]();
+  }
+}
+
+/**
+ * A BubbleSort algorithm
+ *
+ * This sort works by iterating through the list of values from the start
+ * comparing each pair of values and swapping them if they are in the wrong order
+ *
+ * @export
+ * @param {*[]} array the input array
+ * @param {Function} [comparator] a function to compare 2 values (defaults asc->desc)
+ * @param {Function} [step] an optional function that gets applied at each step
+ * @returns {*[]} the sorted array
+ */
+function BubbleSort (array, comparator = (a, b) => a < b, step) {
+  const N = array.length;
+  for (let i = 0; i < N; i++) {
+    for (let j = 0; j < N; j++) {
+      if (comparator(array[j + 1], array[j])) {
+        const tmp = array[j];
+        array[j] = array[j + 1];
+        array[j + 1] = tmp;
+      }
+    }
+    if (step) { step(array); }
+  }
+  return array;
+}
+
+/**
+ * A InsertionSort algorithm
+ *
+ * The sort maintains a sorted (left) and unsorted (right) sections. As each
+ * value is checked, if it's greater than the previous value it gets swapped
+ * to the left until it is no longer greater.
+ *
+ * @export
+ * @param {*[]} array the input array
+ * @param {Function} [comparator] a function to compare 2 values (defaults asc->desc)
+ * @param {Function} [step] an optional function that gets applied at each step
+ * @returns {*[]} the sorted array
+ */
+function InsertionSort (array, comparator = (a, b) => a < b, step) {
+  const N = array.length;
+  for (let i = 1; i < N; i++) {
+    for (let j = i; j > 0; j--) {
+      if (comparator(array[j], array[j - 1])) {
+        [array[j], array[j - 1]] = [array[j - 1], array[j]];
+      }
+    }
+    if (step) { step(array); }
+  }
+
+  return array;
+}
+
+/**
+ * A QuickSort algorithm
+ *
+ * Quicksort chooses an element of the array to serve as the pivot element and
+ * then moves two pointers in from the ends of the array until values are found
+ * that should be swapped to have a more sorted array this is then done recursively
+ * the subarray contained on each side of the pivot until fully sorted.
+ *
+ * @export
+ * @param {*[]} array the input array
+ * @param {Function} [comparator] a function to compare 2 values (defaults asc->desc)
+ * @param {Function} [step] an optional function that gets applied at each step
+ * @returns {*[]} the sorted array
+ */
+function QuickSort (array, comparator, step) {
+  if (array.length < 2) { return; }
+  if (typeof comparator !== 'function') { comparator = (a, b) => a < b; }
+
+  sortRecursive(array, 0, array.length - 1, comparator, step);
+  return array;
+}
+
+const swap = (array, i, j) => {
+  const tmp = array[i];
+  array[i] = array[j];
+  array[j] = tmp;
+};
+
+const hoarePivot = (array, left, right, comparator, step) => {
+  const pivot = Math.floor((left + right) / 2);
+  while (left <= right) {
+    while (comparator(array[left], array[pivot])) {
+      left++;
+    }
+    while (comparator(array[pivot], array[right])) {
+      right--;
+    }
+    if (left <= right) {
+      swap(array, left, right);
+      left++;
+      right--;
+    }
+    if (step) { step(array); }
+  }
+  return left;
+};
+
+const sortRecursive = (array, left, right, comparator, step) => {
+  if (right - left < 1) { return; }
+  const pivot = hoarePivot(array, left, right, comparator, step);
+
+  if (left < pivot - 1) {
+    sortRecursive(array, left, pivot - 1, comparator, step);
+  }
+  if (pivot < right) {
+    sortRecursive(array, pivot, right, comparator, step);
+  }
+};
+
+/**
+ * A SelectionSort algorithm
+ *
+ * The sort works by iterating through the array starting from the beginning.
+ * Each item is compared to every subsequent item in the array to determine
+ * which is smaller. Either the current item is kept or a smaller item is
+ * swapped into its spot. This repeats until the order of items is arranged
+ * from smallest-to-largest.
+ *
+ * @export
+ * @param {*[]} array the input array
+ * @param {Function} [comparator] a function to compare 2 values (defaults asc->desc)
+ * @param {Function} [step] an optional function that gets applied at each step
+ * @returns {*[]} the sorted array
+ */
+function SelectionSort (array, comparator = (a, b) => a < b, step) {
+  const N = array.length;
+  for (let i = 0; i < N; i++) {
+    let min = i;
+    for (let j = i + 1; j < N; j++) {
+      if (comparator(array[j], array[min])) {
+        min = j;
+      }
+    }
+    if (i !== min) {
+      [array[i], array[min]] = [array[min], array[i]];
+    }
+    if (step) { step(array); }
+  }
+
+  return array;
+}
+
+/** A Queue implementation using nodes liked by reference */
+class Stack {
+  /**
+   * The top item of the stack
+   * @private
+   * @type {Object}
+   */
+  top = null;
+
+  /**
+   * The number of items in the stack
+   * @type {number}
+   */
+  size = 0;
+
+  /**
+   * @param {array} [items] an array of items to push onto the stack
+   */
+  constructor (items) {
+    if (items) {
+      this.pushAll(items);
+    }
+  }
+
+  /**
+   * Add an item to the top of the stack
+   *
+   * @param {*} item an item to push onto the stack
+   */
+  push (item = null) {
+    if (item === null) { throw Error('\'item\' parameter not defined'); }
+    if (this.size === 0) {
+      this.top = new StackNode(item, null);
+    } else {
+      const link = this.top;
+      this.top = new StackNode(item, link);
+    }
+    this.size++;
+  }
+
+  /**
+   * Add multiple items to the stack
+   *
+   * @param {*[]} items an array of items to push onto the stack
+   */
+  pushAll (items = null) {
+    if (items === null) { throw Error('\'items\' parameter not defined'); }
+
+    items.forEach(item => this.push(item));
+  }
+
+  /**
+   * Remove and return the top item of the stack
+   *
+   * @returns {*} removes and returns the item on the top of the stack
+   */
+  pop () {
+    if (this.size === 0) { throw Error('can\'t pop an item from an empty stack'); }
+    const item = this.top.data;
+    this.top = this.top.link;
+    this.size--;
+
+    return item;
+  }
+
+  /**
+   * Return the top item of the stack
+   *
+   * @returns {*} the top item on the stack
+   */
+  peek () {
+    if (this.size === 0) { throw Error('can\'t peek an item from an empty stack'); }
+
+    return this.top.data;
+  }
+
+  /**
+   * Remove all items from the stack
+   * @method
+   */
+  clear () {
+    this.top = null;
+    this.size = 0;
+  }
+
+  /**
+   * Iterate all items (top-to-bottom) in the stack
+   *
+   * @private
+   * @returns {Iterator<*>}
+   */
+  [Symbol.iterator] () {
+    let item = this.top;
+    return {
+      next: () => {
+        if (item) {
+          const value = item.data;
+          item = item.link;
+          return { value, done: false };
+        }
+
+        return { value: null, done: true };
+      }
+    };
+  }
+}
+
+/**
+ * @private
+ */
+class StackNode {
+  data;
+  link;
+
+  constructor (data, link = null) {
+    this.data = data;
+    this.link = link;
+  }
+}
+
+/** QuickFind is a simple but less optimal implementation of a UnionFind data structure. */
+class QuickFind {
+  /**
+   * The identity array
+   * @private
+   * @type {Map<any, any>}
+   */
+  verticies = null;
+
+  /**
+   * The number of sets
+   * @type {Number}
+   */
+  count = 0;
+
+  /**
+   * @constructs QuickFind
+   * @param {*[]} [values] an array of verticies to add to the set
+   */
+  constructor (values = []) {
+    this.verticies = new Map();
+    values.forEach((value, i) => {
+      this.verticies.set(value, i);
+    });
+
+    this.count = this.verticies.size;
+  }
+
+  /**
+   * Find the id for a value
+   *
+   * @param {*} value the value to lookup
+   * @returns {Number} the identity of the set containing the item
+   */
+  find (value) {
+    const id = this.verticies.get(value);
+    if (id === undefined) { throw Error(`Item: ${value} not found in the set`); }
+
+    return id;
+  }
+
+  /**
+   * Are the 2 verticies connected?
+   *
+   * @param {*} valueA the first vertex to compare
+   * @param {*} valueB the second vertex to compare
+   * @returns {boolean} true if the verticies are connected, false if not
+   */
+  connected (valueA, valueB) {
+    return this.find(valueA) === this.find(valueB);
+  }
+
+  /**
+   * Join the verticies if not already in the same set
+   *
+   * @param {*} valueA the first vertex to connect
+   * @param {*} valueB the second vertex to connect
+   */
+  union (valueA, valueB) {
+    if (this.connected(valueA, valueB)) { return; }
+
+    const idA = this.find(valueA);
+    const idB = this.find(valueB);
+
+    this.verticies.forEach((id, key) => {
+      if (id === idA) {
+        this.verticies.set(key, idB);
+      }
+    });
+    this.count--;
+  }
+
+  /**
+   * Returns a 2D array of the unique sets and the values in those sets
+   *
+   * @returns [][] a 2D array containing the disjoint sets
+   */
+  sets () {
+    const verticies = [...this.verticies.entries()];
+    const sets = verticies.reduce((acc, curr) => {
+      // create the set array if it doesn't exist
+      if (acc[curr[1]] === undefined) { acc[curr[1]] = []; }
+      acc[curr[1]].push(curr[0]);
+      return acc;
+    }, {});
+
+    return Object.values(sets);
+  }
+}
+
+/** QuickUnion is a slightly more optimal (ie tree-based) implementation of a UnionFind data structure. */
+
+class QuickUnion {
+  /**
+   * The identity array
+   * @private
+   * @type {Map<any, any>}
+   */
+  verticies = null;
+
+  /**
+   * The number of sets
+   * @type {Number}
+   */
+  count = 0;
+
+  /**
+   * @constructs QuickUnion
+   * @param {*[]} [values] an array of verticies to add to the set
+   */
+  constructor (values = []) {
+    this.verticies = new Map();
+    values.forEach((value) => {
+      this.verticies.set(value, value);
+    });
+
+    this.count = this.verticies.size;
+  }
+
+  /**
+   * Find the id for a value
+   *
+   * @param {*} value the value to lookup
+   * @returns {*} the identity of the set containing the item
+   */
+  find (value) {
+    let id = value;
+    while (id !== this.verticies.get(id)) {
+      id = this.verticies.get(id);
+      if (id === undefined) { throw Error(`Item: ${value} not found in the set`); }
+    }
+
+    return id;
+  }
+
+  /**
+   * Are the 2 verticies connected?
+   *
+   * @param {*} valueA the first vertex to compare
+   * @param {*} valueB the second vertex to compare
+   * @returns {boolean} true if the verticies are connected, false if not
+   */
+  connected (valueA, valueB) {
+    return this.find(valueA) === this.find(valueB);
+  }
+
+  /**
+   * Join the verticies if not alredy in the same set
+   *
+   * @param {*} valueA the first vertex to connect
+   * @param {*} valueB the second vertex to connect
+   */
+  union (valueA, valueB) {
+    if (this.connected(valueA, valueB)) { return; }
+
+    const idA = this.find(valueA);
+    const idB = this.find(valueB);
+    this.verticies.set(idA, idB);
+
+    this.count--;
+  }
+
+  /**
+   * Returns a 2D array of the unique sets and the values in those sets
+   *
+   * @returns [][] a 2D array containing the disjoint sets
+   */
+  sets () {
+    const verticies = [...this.verticies.entries()];
+    const sets = verticies.reduce((acc, curr) => {
+      const root = this.verticies.get(curr[1]);
+      // create the set array if it doesn't exist
+      if (acc[root] === undefined) { acc[root] = []; }
+      acc[root].push(curr[0]);
+      return acc;
+    }, {});
+
+    return Object.values(sets);
+  }
+}
+
+export { BubbleSort, InsertionSort, LinkedList, Queue, QuickFind, QuickSort, QuickUnion, SelectionSort, Set, Stack };

--- a/computer-science/package-lock.json
+++ b/computer-science/package-lock.json
@@ -1,0 +1,493 @@
+{
+  "name": "computer-science",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "chokidar": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.3.0"
+      }
+    },
+    "commander": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
+      "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
+      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
+      "dev": true
+    },
+    "readdirp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.7"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "resolve": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
+      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
+      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "tape": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.12.1.tgz",
+      "integrity": "sha512-xoK2ariLmdGxqyXhhxfIZlr0czNB8hNJeVQmHN4D7ZyBn30GUoa4q2oM4cX8jNhnj1mtILXn1ugbfxc0tTDKtA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~1.1.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.6",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "is-regex": "~1.0.5",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.7.0",
+        "resolve": "~1.14.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.2.1",
+        "through": "~2.3.8"
+      }
+    },
+    "tape-es": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tape-es/-/tape-es-1.1.6.tgz",
+      "integrity": "sha512-CWRoUIsTeaagD+CBcMA0iaArgRQMhQhP9MXAYOcle8hI8Fh9jj3JbR7GwTphPHQQlS08kxGzbP8GQAUXn/1wRg==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.3.0",
+        "commander": "^4.0.1",
+        "glob": "^7.1.6",
+        "tape": "^4.11.0"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/computer-science/package.json
+++ b/computer-science/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "computer-science",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "tape-es",
+    "test:watch": "tape-watch-es"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "tape-es": "^1.1.1"
+  },
+  "engines": {
+    "node": ">=13.2"
+  }
+}

--- a/computer-science/tests/BubbleSort.spec.js
+++ b/computer-science/tests/BubbleSort.spec.js
@@ -1,0 +1,23 @@
+import test from 'tape';
+import { BubbleSort } from '../index.min.js';
+
+test('BubbleSort() - should sort the array', t => {
+  const data = ['CC', 'BB', 'BB', 'BB', 'BB', 'CC', 'AA', 'BB'];
+  const expected = ['AA', 'BB', 'BB', 'BB', 'BB', 'BB', 'CC', 'CC'];
+  const result = BubbleSort(data);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});
+
+test('BubbleSort(array) - should sort the array using a custom comparator', t => {
+  const data = ['CC', 'BB', 'BB', 'BB', 'BB', 'CC', 'AA', 'BB'];
+  const expected = ['CC', 'CC', 'BB', 'BB', 'BB', 'BB', 'BB', 'AA'];
+  const descending = (a, b) => a > b;
+  const result = BubbleSort(data, descending);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});

--- a/computer-science/tests/InsertionSort.spec.js
+++ b/computer-science/tests/InsertionSort.spec.js
@@ -1,0 +1,23 @@
+import test from 'tape';
+import { InsertionSort } from '../index.min.js';
+
+test('InsertionSort() - should sort the array', t => {
+  const data = ['CC', 'BB', 'BB', 'BB', 'BB', 'CC', 'AA', 'BB'];
+  const expected = ['AA', 'BB', 'BB', 'BB', 'BB', 'BB', 'CC', 'CC'];
+  const result = InsertionSort(data);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});
+
+test('InsertionSort(array) - should sort the array using a custom comparator', t => {
+  const data = ['CC', 'BB', 'BB', 'BB', 'BB', 'CC', 'AA', 'BB'];
+  const expected = ['CC', 'CC', 'BB', 'BB', 'BB', 'BB', 'BB', 'AA'];
+  const descending = (a, b) => a > b;
+  const result = InsertionSort(data, descending);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});

--- a/computer-science/tests/LinkedList.spec.js
+++ b/computer-science/tests/LinkedList.spec.js
@@ -1,0 +1,199 @@
+import test from 'tape';
+import { LinkedList } from '../index.min.js';
+
+test('new LinkedList() - should create a new empty list', (t) => {
+  const ll = new LinkedList();
+
+  t.notEqual(ll, null, 'LinkedList should exist');
+  t.equal(ll.head, null, 'LinkedList.head should initialize to null');
+  t.equal(ll.tail, null, 'LinkedList.tail should initialize to null');
+  t.equal(ll.size, 0, 'LinkedList.size should be 0');
+
+  t.end();
+});
+
+test('LinkedList.add(item) - should add one item to the list', (t) => {
+  const ll = new LinkedList();
+  const item = 'test1';
+  ll.add(item);
+
+  t.equal(ll.head.data, item, 'LinkedList.head should be the item');
+  t.equal(ll.tail.data, item, 'LinkedList.tail should be the item');
+  t.equal(ll.size, 1, 'LinkedList.size should be 1');
+
+  t.end();
+});
+
+test('LinkedList.add() - should throw when no item is specified', (t) => {
+  t.plan(1);
+  const ll = new LinkedList();
+
+  try {
+    ll.add();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('LinkedList.add(item)* - called multiple times should add multiple items to the list', (t) => {
+  const ll = new LinkedList();
+  const items = ['test1', 'test2', 'test3'];
+  items.forEach(item => ll.add(item));
+
+  t.equal(ll.head.data, items[0], 'LinkedList.head should be the first item');
+  t.equal(ll.tail.data, items[2], 'LinkedList.tail should be the last item');
+  t.equal(ll.size, 3, 'LinkedList.size should be 3');
+
+  t.end();
+});
+
+test('LinkedList.addAll(items) - should add multiple items to the list', (t) => {
+  const ll = new LinkedList();
+  const items = ['test1', 'test2', 'test3'];
+  ll.addAll(items);
+
+  t.equal(ll.head.data, items[0], 'LinkedList.head should be the first item');
+  t.equal(ll.tail.data, items[2], 'LinkedList.tail should be the last item');
+  t.equal(ll.size, 3, 'LinkedList.size should be 3');
+
+  t.end();
+});
+
+test('LinkedList.addAll() - should throw when no items are specified', (t) => {
+  t.plan(1);
+  const ll = new LinkedList();
+
+  try {
+    ll.addAll();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('new LinkedList(items) - should add items during construction', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+
+  t.equal(ll.head.data, items[0], 'LinkedList.head should be the first item');
+  t.equal(ll.tail.data, items[2], 'LinkedList.tail should be the last item');
+  t.equal(ll.size, 3, 'LinkedList.size should be 3');
+
+  t.end();
+});
+
+test('LinkedList.remove(item) - should remove the first item from the list', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+  const result = ll.remove('test1');
+
+  t.equal(ll.head.data, items[1], 'LinkedList.head should be the second item');
+  t.equal(ll.tail.data, items[2], 'LinkedList.tail should be the last item');
+  t.equal(ll.size, 2, 'LinkedList.size should be 2');
+  t.true(result, 'result should return true when an item is removed');
+
+  t.end();
+});
+
+test('LinkedList.remove(item) - should remove a middle item from the list', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+  const result = ll.remove('test2');
+
+  t.equal(ll.head.data, items[0], 'LinkedList.head should be the first item');
+  t.equal(ll.tail.data, items[2], 'LinkedList.tail should be the last item');
+  t.equal(ll.size, 2, 'LinkedList.size should be 2');
+  t.true(result, 'result should return true when an item is removed');
+
+  t.end();
+});
+
+test('LinkedList.remove(item) - should remove the last item from the list', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+  const result = ll.remove('test3');
+
+  t.equal(ll.head.data, items[0], 'LinkedList.head should be the first item');
+  t.equal(ll.tail.data, items[1], 'LinkedList.tail should be the second item');
+  t.equal(ll.size, 2, 'LinkedList.size should be 2');
+  t.true(result, 'result should return true when an item is removed');
+
+  t.end();
+});
+
+test('LinkedList.remove(item)* - called multiple times should remove all items from the list', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+  items.forEach(item => ll.remove(item));
+
+  t.equal(ll.head, null, 'LinkedList.head should reset to null');
+  t.equal(ll.tail, null, 'LinkedList.tail should reset to null');
+  t.equal(ll.size, 0, 'LinkedList.size should be 0');
+
+  t.end();
+});
+
+test('LinkedList.remove(not-item) - should remove nothing from the list', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+  const result = ll.remove('not-item');
+
+  t.equal(ll.head.data, items[0], 'LinkedList.head should be the first item');
+  t.equal(ll.tail.data, items[2], 'LinkedList.tail should be the last item');
+  t.equal(ll.size, 3, 'LinkedList.size should be 3');
+  t.false(result, 'result should return true when an item is removed');
+
+  t.end();
+});
+
+test('LinkedList.remove() - should throw  when no item is specified', (t) => {
+  t.plan(1);
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+
+  try {
+    ll.remove();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('LinkedList.remove(item) - should throw when called on an empty list', (t) => {
+  t.plan(1);
+  const ll = new LinkedList();
+
+  try {
+    ll.remove('test1');
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('LinkedList.clear() - should remove all items from the list', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+  ll.clear();
+
+  t.equal(ll.head, null, 'LinkedList.head should reset to null');
+  t.equal(ll.tail, null, 'LinkedList.tail should reset to null');
+  t.equal(ll.size, 0, 'LinkedList.size should be 0');
+
+  t.end();
+});
+
+test('LinkedList[Symbol.iterator] - should be iterable', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const ll = new LinkedList(items);
+  const result = [...ll];
+
+  t.deepEqual(result, items, 'iteration works');
+
+  t.end();
+});

--- a/computer-science/tests/Queue.spec.js
+++ b/computer-science/tests/Queue.spec.js
@@ -1,0 +1,158 @@
+import test from 'tape';
+import { Queue } from '../index.min.js';
+
+test('new Queue() - should create a new empty queue', (t) => {
+  const q = new Queue();
+
+  t.notEqual(q, null, 'Queue should exist');
+  t.equal(q.first, null, 'Queue.first should initialize to null');
+  t.equal(q.last, null, 'Queue.last should initialize to null');
+  t.equal(q.size, 0, 'Queue.size should be 0');
+
+  t.end();
+});
+
+test('Queue.enqueue(item) - should add one item to the queue', (t) => {
+  const q = new Queue();
+  const item = 'test1';
+  q.enqueue(item);
+
+  t.equal(q.first.data, item, 'Queue.first should be the item');
+  t.equal(q.last.data, item, 'Queue.last should be the item');
+  t.equal(q.size, 1, 'Queue.size should be 1');
+
+  t.end();
+});
+
+test('Queue.enqueue() - should throw when no item is specified', (t) => {
+  t.plan(1);
+  const q = new Queue();
+
+  try {
+    q.enqueue();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('Queue.enqueue(item)* - called multiple times should add multiple items to the queue', (t) => {
+  const q = new Queue();
+  const items = ['test1', 'test2'];
+  items.forEach(item => q.enqueue(item));
+
+  t.equal(q.first.data, items[0], 'Queue.first should be the first item');
+  t.equal(q.last.data, items[1], 'Queue.last should be the second item');
+  t.equal(q.size, 2, 'Queue.size should be 2');
+
+  t.end();
+});
+
+test('Queue.enqueueAll(items) - should add multiple items to the queue', (t) => {
+  const q = new Queue();
+  const items = ['test1', 'test2'];
+  q.enqueueAll(items);
+
+  t.equal(q.first.data, items[0], 'Queue.first should be the first item');
+  t.equal(q.last.data, items[1], 'Queue.last should be the second item');
+  t.equal(q.size, 2, 'Queue.size should be 2');
+
+  t.end();
+});
+
+test('Queue.enqueueAll() - should throw when no items are specified', (t) => {
+  t.plan(1);
+  const q = new Queue();
+
+  try {
+    q.enqueueAll();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('new Queue(items) - should enqueue items during construction', (t) => {
+  const items = ['test1', 'test2'];
+  const q = new Queue(items);
+
+  t.equal(q.first.data, items[0], 'Queue.first should be the first item');
+  t.equal(q.last.data, items[1], 'Queue.last should be the second item');
+  t.equal(q.size, 2, 'Queue.size should be 2');
+
+  t.end();
+});
+
+test('Queue.dequeue(item) - should dequeue an item from the queue', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const q = new Queue(items);
+  const result = q.dequeue();
+
+  t.equal(q.first.data, items[1], 'Queue.first should be the second item');
+  t.equal(q.last.data, items[2], 'Queue.last should be the last item');
+  t.equal(q.size, 2, 'Queue.size should be 2');
+  t.equal(result, items[0], 'result should return the first item');
+
+  t.end();
+});
+
+test('Queue.dequeue(item)* - called multiple times should dequeue all items from the queue', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const q = new Queue(items);
+  for (let i = 0; i < items.length; i++) {
+    q.dequeue();
+  }
+
+  t.equal(q.first, null, 'Queue.first should reset to null');
+  t.equal(q.last, null, 'Queue.last should reset to null');
+  t.equal(q.size, 0, 'Queue.size should be 0');
+
+  t.end();
+});
+
+test('Stack.dequeue() - should throw when called on an empty queue', (t) => {
+  t.plan(1);
+  const q = new Queue();
+
+  try {
+    q.dequeue();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('Queue.peek() - should return the first item of the queue', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const q = new Queue(items);
+  const result = q.peek();
+
+  t.equal(result, items[0], 'Should return the first item in the queue');
+
+  t.end();
+});
+
+test('Queue.clear() - should remove all items from the queue', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const q = new Queue(items);
+  q.clear();
+
+  t.equal(q.first, null, 'Queue.first should reset to null');
+  t.equal(q.last, null, 'Queue.first should reset to null');
+  t.equal(q.size, 0, 'queue.size should be 0');
+
+  t.end();
+});
+
+test('Queue[Symbol.iterator] - should be iterable', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const q = new Queue(items);
+  const result = [...q];
+
+  t.deepEqual(result, items, 'iteration works');
+
+  t.end();
+});

--- a/computer-science/tests/QuickFind.spec.js
+++ b/computer-science/tests/QuickFind.spec.js
@@ -1,0 +1,127 @@
+import test from 'tape';
+import { QuickFind } from '../index.min.js';
+
+test('new QuickFind() - should create an empty set', (t) => {
+  const qf = new QuickFind();
+  const expected = new Map();
+
+  t.notEqual(qf, null, 'QuickFind should exist');
+  t.deepEqual(qf.verticies, expected, 'QuickFind.verticies should initialize to an empty array');
+  t.equal(qf.count, 0, 'QuickFind.count should be 0');
+
+  t.end();
+});
+
+test('new QuickFind() - should create a set with verticies', (t) => {
+  const qf = new QuickFind(['a', 'b', 'c', 'd']);
+  const expected = new Map([
+    ['a', 0],
+    ['b', 1],
+    ['c', 2],
+    ['d', 3]
+  ]);
+
+  t.notEqual(qf, null, 'QuickFind should exist');
+  t.deepEqual(qf.verticies, expected, 'QuickFind.verticies should initialize w/ 4 verticies');
+  t.equal(qf.count, 4, 'QuickFind.count should be 4');
+
+  t.end();
+});
+
+test('new QuickFind(items) - should create a set populated with items', (t) => {
+  const qf = new QuickFind(['a', 'b', 'c', 'd']);
+  const expected = new Map([
+    ['a', 0],
+    ['b', 1],
+    ['c', 2],
+    ['d', 3]
+  ]);
+
+  t.notEqual(qf, null, 'QuickFind should exist');
+  t.deepEqual(qf.verticies, expected, 'QuickFind.verticies should initialize w/ 4 verticies');
+  t.equal(qf.count, 4, 'QuickFind.count should be 4');
+
+  t.end();
+});
+
+test('QuickFind.find(item) - should return the id of the item', (t) => {
+  const qf = new QuickFind(['a', 'b', 'c', 'd']);
+  const expected = 1;
+  const result = qf.find('b');
+
+  t.deepEqual(result, expected, 'QuickFind.find should return the correct id');
+
+  t.end();
+});
+
+test('QuickFind.find(item) - should throw if the item is not in the set', (t) => {
+  t.plan(1);
+  const qf = new QuickFind(['a', 'b', 'c', 'd']);
+
+  try {
+    qf.find('x');
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('QuickFind.connected(itemA, itemB) - should return false if the verticies are not connected', (t) => {
+  const qf = new QuickFind(['a', 'b', 'c', 'd']);
+  const result = qf.connected('a', 'b');
+
+  t.deepEqual(result, false, 'QuickFind.connected should return false');
+
+  t.end();
+});
+
+test('QuickFind.connected(itemA, itemB) - should return true if the verticies are connected', (t) => {
+  const qf = new QuickFind(['a', 'b', 'c', 'd']);
+  qf.verticies.set('c', 1);
+  const result = qf.connected('b', 'c');
+
+  t.deepEqual(result, true, 'QuickFind.connected should return true');
+
+  t.end();
+});
+
+test('QuickFind.connected(itemA, itemB) - should return true if the verticies are connected', (t) => {
+  const qf = new QuickFind([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  qf.union(4, 3);
+  qf.union(3, 8);
+  qf.union(6, 5);
+  qf.union(9, 4);
+  qf.union(2, 1);
+  qf.union(5, 0);
+  qf.union(7, 2);
+  qf.union(6, 1);
+  const expected = [1, 1, 1, 8, 8, 1, 1, 1, 8, 8];
+  const result = [...qf.verticies.values()];
+
+  t.deepEqual(result, expected, 'QuickFind.verticies should have the correct data');
+  t.equal(qf.count, 2, 'QuickFind.count should be 2');
+
+  t.end();
+});
+
+test('QuickFind.sets() - Returns a 2D array containing the sets of joined verticies', (t) => {
+  const qf = new QuickFind([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  qf.union(4, 3);
+  qf.union(3, 8);
+  qf.union(6, 5);
+  qf.union(9, 4);
+  qf.union(2, 1);
+  const expected = [
+    [0],
+    [1, 2],
+    [5, 6],
+    [7],
+    [3, 4, 8, 9]
+  ];
+  const result = qf.sets();
+
+  t.deepEqual(result, expected, 'Outputs the correct sets');
+
+  t.end();
+});

--- a/computer-science/tests/QuickSort.spec.js
+++ b/computer-science/tests/QuickSort.spec.js
@@ -1,0 +1,33 @@
+import test from 'tape';
+import { QuickSort } from '../index.min.js';
+
+test('QuickSort(array) - should sort the array', t => {
+  const data = ['CC', 'BB', 'BB', 'BB', 'BB', 'CC', 'AA', 'BB'];
+  const expected = ['AA', 'BB', 'BB', 'BB', 'BB', 'BB', 'CC', 'CC'];
+  const result = QuickSort(data);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});
+
+test('QuickSort(array) - should sort the array', t => {
+  const data = [5, 3, 88, 1, 23, 5, 0, -4];
+  const expected = [-4, 0, 1, 3, 5, 5, 23, 88];
+  const result = QuickSort(data);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});
+
+test('QuickSort(array, comparator) - should sort the array using a custom comparator', t => {
+  const data = ['CC', 'BB', 'BB', 'BB', 'CC', 'AA', 'BB'];
+  const expected = ['CC', 'CC', 'BB', 'BB', 'BB', 'BB', 'AA'];
+  const descending = (a, b) => a > b;
+  const result = QuickSort(data, descending);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});

--- a/computer-science/tests/QuickUnion.spec.js
+++ b/computer-science/tests/QuickUnion.spec.js
@@ -1,0 +1,127 @@
+import test from 'tape';
+import { QuickUnion } from '../index.min.js';
+
+test('new QuickUnion() - should create an empty set', (t) => {
+  const qu = new QuickUnion();
+  const expected = new Map();
+
+  t.notEqual(qu, null, 'QuickUnion should exist');
+  t.deepEqual(qu.verticies, expected, 'QuickUnion.verticies should initialize to an empty array');
+  t.equal(qu.count, 0, 'QuickUnion.count should be 0');
+
+  t.end();
+});
+
+test('new QuickUnion() - should create a set with verticies', (t) => {
+  const qu = new QuickUnion(['a', 'b', 'c', 'd']);
+  const expected = new Map([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+    ['d', 4]
+  ]);
+
+  t.notEqual(qu, null, 'QuickUnion should exist');
+  t.deepEqual(qu.verticies, expected, 'QuickUnion.verticies should initialize w/ 4 verticies');
+  t.equal(qu.count, 4, 'QuickUnion.count should be 4');
+
+  t.end();
+});
+
+test('new QuickUnion(items) - should create a set populated with items', (t) => {
+  const qu = new QuickUnion(['a', 'b', 'c', 'd']);
+  const expected = new Map([
+    ['a', 0],
+    ['b', 1],
+    ['c', 2],
+    ['d', 3]
+  ]);
+
+  t.notEqual(qu, null, 'QuickUnion should exist');
+  t.deepEqual(qu.verticies, expected, 'QuickUnion.verticies should initialize w/ 4 verticies');
+  t.equal(qu.count, 4, 'QuickUnion.count should be 4');
+
+  t.end();
+});
+
+test('QuickUnion.find(item) - should return the id of the item', (t) => {
+  const qu = new QuickUnion(['a', 'b', 'c', 'd']);
+  const expected = 'b';
+  const result = qu.find('b');
+
+  t.deepEqual(result, expected, 'QuickUnion.find should return the correct id');
+
+  t.end();
+});
+
+test('QuickUnion.find(item) - should throw if the item is not in the set', (t) => {
+  t.plan(1);
+  const qu = new QuickUnion(['a', 'b', 'c', 'd']);
+
+  try {
+    qu.find('x');
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('QuickUnion.connected(itemA, itemB) - should return false if the verticies are not connected', (t) => {
+  const qu = new QuickUnion(['a', 'b', 'c', 'd']);
+  const result = qu.connected('a', 'b');
+
+  t.deepEqual(result, false, 'QuickFind.connected should return false');
+
+  t.end();
+});
+
+test('QuickUnion.connected(itemA, itemB) - should return true if the verticies are connected', (t) => {
+  const qu = new QuickUnion(['a', 'b', 'c', 'd']);
+  qu.verticies.set('c', 'b');
+  const result = qu.connected('b', 'c');
+
+  t.deepEqual(result, true, 'QuickUnion.connected should return true');
+
+  t.end();
+});
+
+test('QuickUnion.connected(itemA, itemB) - should return true if the verticies are connected', (t) => {
+  const qu = new QuickUnion([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  qu.union(4, 3);
+  qu.union(3, 8);
+  qu.union(6, 5);
+  qu.union(9, 4);
+  qu.union(2, 1);
+  qu.union(5, 0);
+  qu.union(7, 2);
+  qu.union(6, 1);
+  const expected = [1, 1, 1, 8, 3, 0, 5, 1, 8, 8];
+  const result = [...qu.verticies.values()];
+
+  t.deepEqual(result, expected, 'QuickUnion.verticies should have the correct data');
+  t.equal(qu.count, 2, 'QuickUnion.count should be 2');
+
+  t.end();
+});
+
+test('QuickUnion.sets() - Returns a 2D array containing the sets of joined verticies', (t) => {
+  const qu = new QuickUnion([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  qu.union(4, 3);
+  qu.union(3, 8);
+  qu.union(6, 5);
+  qu.union(9, 4);
+  qu.union(2, 1);
+  const expected = [
+    [0],
+    [1, 2],
+    [5, 6],
+    [7],
+    [3, 4, 8, 9]
+  ];
+  const result = qu.sets();
+
+  t.deepEqual(result, expected, 'Outputs the correct sets');
+
+  t.end();
+});

--- a/computer-science/tests/SelectionSort.spec.js
+++ b/computer-science/tests/SelectionSort.spec.js
@@ -1,0 +1,23 @@
+import test from 'tape';
+import { SelectionSort } from '../index.min.js';
+
+test('SelectionSort() - should sort the array', t => {
+  const data = ['CC', 'BB', 'BB', 'BB', 'BB', 'CC', 'AA', 'BB'];
+  const expected = ['AA', 'BB', 'BB', 'BB', 'BB', 'BB', 'CC', 'CC'];
+  const result = SelectionSort(data);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});
+
+test('SelectionSort(array) - should sort the array using a custom comparator', t => {
+  const data = ['CC', 'BB', 'BB', 'BB', 'BB', 'CC', 'AA', 'BB'];
+  const expected = ['CC', 'CC', 'BB', 'BB', 'BB', 'BB', 'BB', 'AA'];
+  const descending = (a, b) => a > b;
+  const result = SelectionSort(data, descending);
+
+  t.deepEqual(expected, result, 'Output should be sorted');
+
+  t.end();
+});

--- a/computer-science/tests/Set.spec.js
+++ b/computer-science/tests/Set.spec.js
@@ -1,0 +1,143 @@
+import test from 'tape';
+import { Set } from '../index.min.js';
+
+test('new Set() - should create a new empty set', (t) => {
+  const s = new Set();
+
+  t.notEqual(s, null, 'Set should exist');
+  t.equal(s.size, 0, 'Set.size should be 0');
+
+  t.end();
+});
+
+test('Set.add(item) - should add one item to the set', (t) => {
+  const s = new Set();
+  const item = 'test1';
+  s.add(item);
+
+  t.deepEqual(s.values, [item], 'Set.values should contain the item');
+  t.equal(s.size, 1, 'Set.size should be 1');
+
+  t.end();
+});
+
+test('Set.add(item) - called multiple times with the same item should not contain duplicates', (t) => {
+  const s = new Set();
+  const item = 'test1';
+  s.add(item);
+  s.add(item);
+  s.add(item);
+
+  t.deepEqual(s.values, [item], 'Set.values should contain the item');
+  t.equal(s.size, 1, 'Set.size should be 1');
+
+  t.end();
+});
+
+test('Set.add() - should throw when no item is specified', (t) => {
+  t.plan(1);
+  const s = new Set();
+
+  try {
+    s.add();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('Set.addAll(items) - should add multiple items to the Set', (t) => {
+  const s = new Set();
+  const items = ['test1', 'test2', 'test3'];
+  s.addAll(items);
+
+  t.deepEqual(s.values, items, 'Set.values should be contain all 3 items');
+  t.equal(s.size, 3, 'Set.size should be 3');
+
+  t.end();
+});
+
+test('Set.addAll() - should throw when no items are specified', (t) => {
+  t.plan(1);
+  const s = new Set();
+
+  try {
+    s.addAll();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('new Set(items) - should add items during construction', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Set(items);
+
+  t.deepEqual(s.values, items, 'Set.values should contain the items');
+  t.equal(s.size, 3, 'Set.size should be 3');
+
+  t.end();
+});
+
+test('Set.remove(item) - should remove the item from the set', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Set(items);
+  const result = s.remove('test1');
+  const expect = ['test2', 'test3'];
+
+  t.deepEqual(s.values, expect, 'Set.values should not contain the removed item');
+  t.equal(s.size, 2, 'Set.size should be 2');
+  t.true(result, 'result should return true when an item is removed');
+
+  t.end();
+});
+
+test('Set.remove(item) - should not remove an item not in the set', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Set(items);
+  const result = s.remove('test4');
+  const expect = ['test1', 'test2', 'test3'];
+
+  t.deepEqual(s.values, expect, 'Set.values should not be modified');
+  t.equal(s.size, 3, 'Set.size should be 3');
+  t.false(result, 'result should return false if the item is not in the set');
+
+  t.end();
+});
+
+test('Set.remove() - should throw when no item is specified', (t) => {
+  t.plan(1);
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Set(items);
+
+  try {
+    s.remove();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('Set.clear() - should remove all items from the set', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Set(items);
+  s.clear();
+
+  t.deepEqual(s.values, [], 'Set.values should be empty');
+  t.equal(s.size, 0, 'Set.size should be 0');
+
+  t.end();
+});
+
+test('Set[Symbol.iterator] - should be iterable', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Set(items);
+  const result = [...s];
+
+  t.deepEqual(result, items, 'iteration works');
+
+  t.end();
+});

--- a/computer-science/tests/Stack.spec.js
+++ b/computer-science/tests/Stack.spec.js
@@ -1,0 +1,150 @@
+import test from 'tape';
+import { Stack } from '../index.min.js';
+
+test('new Stack() - should create a new empty stack', (t) => {
+  const s = new Stack();
+
+  t.notEqual(s, null, 'Stack should exist');
+  t.equal(s.top, null, 'Stack.top should initialize to null');
+  t.equal(s.size, 0, 'Stack.size should be 0');
+
+  t.end();
+});
+
+test('Stack.push(item) - should add one item to the stack', (t) => {
+  const s = new Stack();
+  const item = 'test1';
+  s.push(item);
+
+  t.equal(s.top.data, item, 'Stack.top should be the item');
+  t.equal(s.size, 1, 'Stack.size should be 1');
+
+  t.end();
+});
+
+test('Stack.push() - should throw when no item is specified', (t) => {
+  t.plan(1);
+  const s = new Stack();
+
+  try {
+    s.push();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('Stack.push(item)* - called multiple times should add multiple items to the stack', (t) => {
+  const s = new Stack();
+  const items = ['test1', 'test2', 'test3'];
+  items.forEach(item => s.push(item));
+
+  t.equal(s.top.data, items[2], 'Stack.top should be the last item');
+  t.equal(s.size, 3, 'Stack.size should be 3');
+
+  t.end();
+});
+
+test('Stack.pushAll(items) - should add multiple items to the stack', (t) => {
+  const s = new Stack();
+  const items = ['test1', 'test2', 'test3'];
+  s.pushAll(items);
+
+  t.equal(s.top.data, items[2], 'Stack.top should be the last item');
+  t.equal(s.size, 3, 'Stack.size should be 3');
+
+  t.end();
+});
+
+test('Stack.pushAll() - should throw when no items are specified', (t) => {
+  t.plan(1);
+  const s = new Stack();
+
+  try {
+    s.pushAll();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('new Stack(items) - should push items during construction', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Stack(items);
+
+  t.equal(s.top.data, items[2], 'Stack.top should be the last item');
+  t.equal(s.size, 3, 'Stack.size should be 3');
+
+  t.end();
+});
+
+test('Stack.pop() - should remove and return the top item', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Stack(items);
+  const result = s.pop();
+
+  t.equal(s.top.data, items[1], 'Stack.top should be the second item');
+  t.equal(s.size, 2, 'Stack.size should be 2');
+  t.equal(result, items[2], 'result should return the popped item');
+
+  t.end();
+});
+
+test('Stack.pop()* - called multiple times should remove all items from the stack', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Stack(items);
+  for (let i = 0; i < items.length; i++) {
+    s.pop();
+  }
+
+  t.equal(s.top, null, 'Stack.top should reset to null');
+  t.equal(s.size, 0, 'Stack.size should be 0');
+
+  t.end();
+});
+
+test('Stack.pop() - should throw when called on an empty stack', (t) => {
+  t.plan(1);
+  const s = new Stack();
+
+  try {
+    s.pop();
+  } catch (e) {
+    t.pass('Expected exception thrown');
+  }
+
+  t.end();
+});
+
+test('Stack.peek() - should return the top item of the stack', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Stack(items);
+  const result = s.peek();
+
+  t.equal(result, items[2], 'Should return the top item of the stack');
+
+  t.end();
+});
+
+test('Stack.clear() - should remove all items from the stack', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Stack(items);
+  s.clear();
+
+  t.equal(s.top, null, 'Stack.top should reset to null');
+  t.equal(s.size, 0, 'Stack.size should be 0');
+
+  t.end();
+});
+
+test('Stack[Symbol.iterator] - should be iterable', (t) => {
+  const items = ['test1', 'test2', 'test3'];
+  const s = new Stack(items);
+  const result = [...s];
+
+  t.deepEqual(result, items.reverse(), 'iteration works');
+
+  t.end();
+});

--- a/tests/computer-science.js
+++ b/tests/computer-science.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { readFileSync, writeFileSync } = require('fs');
+const { execSync } = require('child_process');
+const { minify } = require('terser');
+
+process.chdir(process.cwd() + '/computer-science');
+execSync('npm i');
+
+const code = readFileSync('../computer-science/index.js').toString();
+const minified = minify(code);
+assert(!minified.error)
+writeFileSync('../computer-science/index.min.js', minified.code)
+
+execSync('npm t', { stdio: ['pipe', process.stdout, process.stderr] });


### PR DESCRIPTION
Ref #93 

The good news is... terser not only works with but flawlessly minifies ESM.
The bad news is... terser can't minify public props but I'm guessing you were expecting as much

**Usage**

From the root dir run...

```sh
node tests/computer-science.js
```

**ESM**

Like I noted previously, this is an ESM package. Meaning, `"type": "module"` is set and all .js files within the package boundary are interpreted as ES modules, not CommonJS modules.

This requires at least Node >= 13.2 to run, otherwise it'll error out with 'unexpected statement' errors. Also, ignore all the 'Experimental' warning noise in the output. AFAIK, the node/modules team wants to keep displaying this notice until the `pkg.exports` stuff lands.

**Bundling**

Bundling the source was interesting. Class props can't be processed by any bundler so I ended up commenting them out and uncommenting after bundling.

The tests for 'computer-science' are extensive. They *will* fail if default values set using class props aren't set. I verified that both minification and all tests passed by running this after manually setting the defaults in each class's constructor. For example

```javascript
head = null
// becomes
constructor() {
    this.head = null;
}
```

**Testing**

For the test runner, it isn't Tape. Since the subprocesses complete non-deterministically, the order of results isn't guaranteed. Fortunately, if any test fails the runner will return `exitCode = 1`. To see the output, I piped the test results to stdout/stderr.