### PR TITLE
Added error message to assert statement

### DIFF
--- a/tests/computer-science.js
+++ b/tests/computer-science.js
@@ -10,7 +10,7 @@ execSync('npm i');
 
 const code = readFileSync('../computer-science/index.js').toString();
 const minified = minify(code);
-assert(!minified.error)
+assert(!minified.error, minified.error)
 writeFileSync('../computer-science/index.min.js', minified.code)
 
 execSync('npm t', { stdio: ['pipe', process.stdout, process.stderr] });


### PR DESCRIPTION
Assert has signature: `assert(value[, message])` where message is optional and may be `string` or `Error`. In case if asserts fails message will be shown